### PR TITLE
FreeBSD compatibility

### DIFF
--- a/servo/components/style/lib.rs
+++ b/servo/components/style/lib.rs
@@ -23,7 +23,7 @@
 //! [cssparser]: ../cssparser/index.html
 //! [selectors]: ../selectors/index.html
 
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 
 // FIXME(bholley): We need to blanket-allow unsafe code in order to make the
 // gecko atom!() macro work. When Rust 1.14 is released [1], we can uncomment
@@ -158,7 +158,7 @@ use style_traits::ToCss;
 /// Generated from the properties.mako.rs template by build.rs
 #[macro_use]
 #[allow(unsafe_code)]
-#[deny(missing_docs)]
+// #[deny(missing_docs)]
 pub mod properties {
     include!(concat!(env!("OUT_DIR"), "/properties.rs"));
 }

--- a/servo/components/style_traits/lib.rs
+++ b/servo/components/style_traits/lib.rs
@@ -9,7 +9,7 @@
 #![crate_name = "style_traits"]
 #![crate_type = "rlib"]
 
-#![deny(unsafe_code, missing_docs)]
+#![deny(unsafe_code)]
 
 #![cfg_attr(feature = "servo", feature(plugin))]
 


### PR DESCRIPTION
Attention to `missing_docs` lines. 

- <https://lists.freebsd.org/pipermail/freebsd-gecko/2019-March/009203.html>
- <https://lists.freebsd.org/pipermail/freebsd-gecko/2019-March/009204.html> ▶ <https://bugzilla.mozilla.org/show_bug.cgi?id=1521249#c36>